### PR TITLE
Add awesome people in Accessibility (Rob and Ire)

### DIFF
--- a/topics/people.md
+++ b/topics/people.md
@@ -22,6 +22,7 @@ This is a list, in no particular order, of people to follow that contribute grea
 | Greg Tarnoff | [@gregtarnoff](https://twitter.com/gregtarnoff) |
 | Hector Minto| [@hminto](https://twitter.com/hminto) |
 | Heydon Works | [@heydonworks](http://twitter.com/heydonworks) |
+| Ire Aderinokun | [@ireaderinokun](http://twitter.com/ireaderinokun) |
 | Jeffrey Zeldman |	[@zeldman](https://twitter.com/zeldman) |
 | Jen Simmons |	[@jensimmons](https://twitter.com/jensimmons) |
 | Joe Dolson   | [@joedolson](https://twitter.com/joedolson) |
@@ -41,6 +42,7 @@ This is a list, in no particular order, of people to follow that contribute grea
 | Neil Milliken |	[@NeilMilliken](https://twitter.com/NeilMilliken) |
 | Patrick Fox |	[@patrickfox](https://twitter.com/patrickfox) |
 | Reinaldo Ferraz | [@reinaldoferraz](https://twitter.com/reinaldoferraz) |
+| Rob Dodson | [@rob_dodson](https://twitter.com/rob_dodson) |
 | Scott O'Hara | [@scottohara](https://twitter.com/scottohara) |
 | Scott Vinkle | [@svinkle](https://twitter.com/svinkle) |
 | Shawn Lawton Henry | [@shawn_slh](https://twitter.com/shawn_slh) |


### PR DESCRIPTION
Hi Bruno, my name's Kresna. I'm exciting about a11y especially on the web. Thanks for providing this awesome repo. I want to add 2 person that I think involve in Accessibility world.

1. Rob Dodson. He's Developer Advocate from Chrome team. Currently he's focusing on Accessibility and create [A11ycast](https://www.youtube.com/watch?v=Ag3DMNbL_ig&list=PLNYkxOF6rcICWx0C9LVWWVqvHlYJyqw7g) playlist.

2. Ire Aderinokun. She's Google Developer Expert on the Web. I check her article and she create awesome article ([Accessibility Cheat sheet](https://bitsofco.de/the-accessibility-cheatsheet/)). For more article about a11y that she created please check [here](https://bitsofco.de/tag/accessibility/).

I hope you consider to add both of them. Thanks a lot.