### PR TITLE
Meetups updates

### DIFF
--- a/topics/meetups.md
+++ b/topics/meetups.md
@@ -1,25 +1,38 @@
 ## Meetups
 
-| Name | Link |
-| --- | --- |
-| #a11yTO	|[@a11yTO](https://twitter.com/a11yTO)|
-| A11Y | [@a11y](https://twitter.com/a11y)|
-| a11yBytes | [@a11ybytes](https://twitter.com/a11ybytes)|
-| A11YChi Meetup | [@A11YCh](https://twitter.com/A11YChi)|
-| a11yEdinburgh | [@a11yEdinburgh](https://twitter.com/a11yedinburgh/)|
-| a11yLondon | [@a11yLondon](https://twitter.com/a11yLondon)|
-| a11yMTL | [@a11yMTL](https://twitter.com/a11yMTL)|
-| a11yQC | [@a11yqc](https://twitter.com/a11yqc/)|
-| A11YRTP | [@A11yRtp](https://twitter.com/A11yRtp)|
-| A11y Scottland | [@a11yscotland](https://twitter.com/a11yscotland)
-| A11ySEA | [@a11ysea](https://twitter.com/a11ysea)|
-| AccessibilityBayArea | [@a11ybay](https://twitter.com/a11ybay)|
-| AccessibilityDC | [@AccessibilityDC](https://twitter.com/AccessibilityDC)|
-| AccessibilityNYC | [@a11yNYC](https://twitter.com/a11yNYC)|
-| Accessibility Ottawa | [@a11yYOW](https://twitter.com/a11yYOW)|
-| Buffa11y | [@buffa11y](https://twitter.com/buffa11y)|
-| MidMO Accessibility | [@MidMOA11Y](https://twitter.com/MidMOA11Y)|
-| Open | [@openmcr](https://twitter.com/openmcr)|
-| Portland Accessibility and User Experience (PDXAUX)|[PDXAUX on Meetup](https://www.meetup.com/Portland-Accessibility-and-User-Experience-Meetup/)|
-| role=drinks | [@roledrinks](https://twitter.com/roledrinks)|
-| WebA11y.jp［エーイレブンワイ | [@weba11y](https://twitter.com/weba11y)|
+### Canada
+
+| Name    | City / Province | Link |
+|---      |---              |---   |
+| #a11yTO	| Toronto | [@a11yTO](https://twitter.com/a11yTO) |
+| a11yMTL | Montreal | [@a11yMTL](https://twitter.com/a11yMTL) |
+| a11yQC | Quebec | [@a11yqc](https://twitter.com/a11yqc/) |
+| Accessibility Ottawa | Ottawa | [@a11yYOW](https://twitter.com/a11yYOW) |
+
+### Europe
+
+| Name | City / Country | Link |
+|---   |---             |---   |
+| Accessibility Scotland | Scotland | [@a11yscotland](https://twitter.com/a11yscotland) |
+| London Accessibility | London, England | [@a11yLondon](https://twitter.com/a11yLondon) |
+| Open | Manchester, England | [@openmcr](https://twitter.com/openmcr) |
+| role=drinks | Multiple locations | [@roledrinks](https://twitter.com/roledrinks) |
+
+### Japan
+
+| Name | City / Country | Link |
+|---   |---             |---   |
+| WebA11y.jp［エーイレブンワイ | Tokyo, Japan | [@weba11y](https://twitter.com/weba11y) |
+
+### USA
+
+| Name | City / State | Link |
+|---   |---           |---   |
+| AccessibilityBayArea | San Francisco, CA | [@a11ybay](https://twitter.com/a11ybay) |
+| Accessibility Chicago | Chicago, IL | [@A11YCh](https://twitter.com/A11YChi) |
+| Accessibility DC | Washington, DC | [@AccessibilityDC](https://twitter.com/AccessibilityDC) |
+| AccessibilityNYC | New York City, NY | [@a11yNYC](https://twitter.com/a11yNYC) |
+| A11ySEA | Seattle, WA | [@a11ysea](https://twitter.com/a11ysea) |
+| Buffa11y | Buffalo, NY | [@buffa11y](https://twitter.com/buffa11y) |
+| MidMO Accessibility | Colombia, MO | [@MidMOA11Y](https://twitter.com/MidMOA11Y) |
+| Portland Accessibility and User Experience (PDXAUX) | Portland, OR | [PDXAUX on Meetup](https://www.meetup.com/Portland-Accessibility-and-User-Experience-Meetup/) |

--- a/topics/meetups.md
+++ b/topics/meetups.md
@@ -36,3 +36,5 @@
 | Buffa11y | Buffalo, NY | [@buffa11y](https://twitter.com/buffa11y) |
 | MidMO Accessibility | Colombia, MO | [@MidMOA11Y](https://twitter.com/MidMOA11Y) |
 | Portland Accessibility and User Experience (PDXAUX) | Portland, OR | [PDXAUX on Meetup](https://www.meetup.com/Portland-Accessibility-and-User-Experience-Meetup/) |
+
+> Find meetups in your area through [meetups.com](https://www.meetup.com/find/?allMeetups=false&keywords=a11y&radius=Infinity&sort=recommended&eventFilter=mysugg)


### PR DESCRIPTION
1. Breaking up large table into smaller tables per country / region
2. Adding city / country | state | province column
3. Alphabetizing tables
4. Normalizing table structures.
5. Added link to Meetups.com. Since there are hundreds of meetups all over the world, which naturally come and go frequently, it'd be good to hook people up with a way to find more in their area. I'm not happy with how small it renders on Github though, so this could probably be improved later.