### PR TITLE
Update resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Image is an illustration by [Heydon Pickering](http://www.heydonworks.com/) whic
 - [Assistive Technology](topics/assistive-technology.md)
 - [Books](topics/books.md)
 - [Companies and Organizations](topics/companies-and-organizations.md)
+- [Conferences](topics/conferences.md)
 - [Courses](topics/courses.md)
 - [Development Testing and Validators](topics/validators.md)
 - [Guides](topics/guides.md)

--- a/topics/companies-and-organizations.md
+++ b/topics/companies-and-organizations.md
@@ -20,11 +20,13 @@
 | [Knowbility](https://knowbility.org/) | [@knowbility](https://twitter.com/knowbility) | Auditing, consulting, and training |
 | [Level Access](https://www.levelaccess.com/) | [@LevelAccessA11y](https://twitter.com/LevelAccessA11y) | Auditing, consulting, training, and developemnt |
 | [Microsoft Accessibility](https://www.microsoft.com/en-us/accessibility/) | [@MSFTEnable](https://twitter.com/MSFTEnable) | R&D and accessibility help desk for Microsoft products |
+| [NV Access](https://www.nvaccess.org/) | [@NVAccess](https://twitter.com/NVAccess) | NVDA screen reader, training |
 | [Open Inclusion](https://openinclusion.com/) | [@openforaccess](https://twitter.com/openforaccess) | Market research |
 | [Oswald Labs](https://oswaldlabs.com/) | [@OswaldLabs](https://twitter.com/oswaldlabs) | Product development and accelerator |
 | [Simply Accessible](http://simplyaccessible.com/) | [@SAteaches](https://twitter.com/sateaches) | Auditing, consulting, development, training, and user research |
 | [The Paciello Group](https://www.paciellogroup.com/) | [@paciellogroup](https://twitter.com/paciellogroup) | Auditing, consulting, training, and products |
 | Twitter Accessibility | [@TwitterA11y](https://twitter.com/TwitterA11y) | Feed of accessibility-related updates from Twitter dev team |
+| [UsableNet](https://usablenet.com/) | [@Usablenet](https://twitter.com/Usablenet) | Auditing, consulting, training, and products |
 | [WAI at W3C](https://www.w3.org/WAI/) | [@w3c_wai](https://twitter.com/w3c_wai) | Initiative that develops guidelines and standards like WCAG and ARIA |
 | [WebAIM](https://webaim.org/) | [@webaim](https://twitter.com/webaim) | Auditing, consulting, and training |
 | [Web Axe](http://www.webaxe.org/) | [@webaxe](https://twitter.com/webaxe) | Blog and podcast on accessibility |

--- a/topics/conferences.md
+++ b/topics/conferences.md
@@ -1,0 +1,11 @@
+## Conferences
+
+| Name                                                           | Twitter                                                 |
+| -------------------------------------------------------------- | ------------------------------------------------------- |
+| [a11yTO Conf](https://conf.a11yto.com/)                        | [a11yTO](https://twitter.com/a11yTO)                    |
+| [axe-con](https://www.deque.com/axe-con/)                      | [dequesystems](https://twitter.com/dequesystems)        |
+| [Incluside Design 24](https://inclusivedesign24.org)           | [id24conf](https://twitter.com/id24conf)                |
+| [Web4All](https://www.w4a.info/)                               | [@w4a_conference](https://twitter.com/w4a_conference)   |
+| [WordPress Accessibility Day](https://wpaccessibilityday.org/) | [@WPAccessibility](https://twitter.com/WPAccessibility) |
+
+Digital A11y maintains their own [accessibility conference list](https://www.digitala11y.com/accessibility-conferences-events/).

--- a/topics/meetups.md
+++ b/topics/meetups.md
@@ -1,10 +1,16 @@
 ## Meetups
 
+### Australia
+
+| Name    | City | Link |
+|---      |---              |---   |
+| #a11ybytes | Multiple locations | [@a11ybytes](https://twitter.com/a11ybytes) |
+
 ### Canada
 
 | Name    | City / Province | Link |
 |---      |---              |---   |
-| #a11yTO	| Toronto | [@a11yTO](https://twitter.com/a11yTO) |
+| #a11yTO | Toronto | [@a11yTO](https://twitter.com/a11yTO) |
 | a11yMTL | Montreal | [@a11yMTL](https://twitter.com/a11yMTL) |
 | a11yQC | Quebec | [@a11yqc](https://twitter.com/a11yqc/) |
 | Accessibility Ottawa | Ottawa | [@a11yYOW](https://twitter.com/a11yYOW) |
@@ -13,9 +19,14 @@
 
 | Name | City / Country | Link |
 |---   |---             |---   |
+| A11y Berlin | Berlin, Germany | [@a11yberlin](https://twitter.com/a11yberlin) |
+| Accessibility Club | Nürnberg, Germany | [@a11yclub](https://twitter.com/a11yclub) |
 | Accessibility Scotland | Scotland | [@a11yscotland](https://twitter.com/a11yscotland) |
+| Bristol Inclusive Design & Development | Bristol, England | [@BrisInclusive](https://twitter.com/BrisInclusive) |
+| Budapest Accessibility Meetup | Budapest, Hungary | [@a11ybudapest](https://www.meetup.com/Budapest-Accessibility-Meetup/) |
 | London Accessibility | London, England | [@a11yLondon](https://twitter.com/a11yLondon) |
 | Open | Manchester, England | [@openmcr](https://twitter.com/openmcr) |
+| Paris Web Accessibility | Paris, France | [Paris Web Accessibility](https://www.meetup.com/Paris-Web-Accessibility/) |
 | role=drinks | Multiple locations | [@roledrinks](https://twitter.com/roledrinks) |
 
 ### Japan
@@ -32,8 +43,12 @@
 | Accessibility Chicago | Chicago, IL | [@A11YCh](https://twitter.com/A11YChi) |
 | Accessibility DC | Washington, DC | [@AccessibilityDC](https://twitter.com/AccessibilityDC) |
 | AccessibilityNYC | New York City, NY | [@a11yNYC](https://twitter.com/a11yNYC) |
+| a11yPHL | Philadelphia, PA | [@a11yphl](https://www.meetup.com/a11yphl/) |
+| a11yRTP | Raleigh, NC | [@a11yrtp](https://www.meetup.com/a11yrtp/) |
 | A11ySEA | Seattle, WA | [@a11ysea](https://twitter.com/a11ysea) |
+| AnnArborA11y | Ann Arbor, MI | [@annarbora11y](https://twitter.com/annarbora11y) |
 | Buffa11y | Buffalo, NY | [@buffa11y](https://twitter.com/buffa11y) |
+| Cleveland Accessibility Meetup | Cleveland, OH | [@A11yCLE](https://www.meetup.com/Cleveland-Accessibility-Meetup/) |
 | MidMO Accessibility | Colombia, MO | [@MidMOA11Y](https://twitter.com/MidMOA11Y) |
 | Portland Accessibility and User Experience (PDXAUX) | Portland, OR | [PDXAUX on Meetup](https://www.meetup.com/Portland-Accessibility-and-User-Experience-Meetup/) |
 

--- a/topics/people.md
+++ b/topics/people.md
@@ -14,13 +14,20 @@ This is a list, in no particular order, of people to follow that contribute grea
 | Anand Chowdhary | [@anandchowdhary](https://twitter.com/anandchowdhary) |
 | Andrea Skeries | [@Artistic_Abode](https://twitter.com/Artistic_Abode) |
 | Andrew Arch | [@amja](https://twitter.com/amja) |
+| Andy Ronksley | [@RooRonks](https://twitter.com/RooRonks) |
+| Arthur Rigaud | [@arigaud_ca](https://twitter.com/arigaud_ca) |
 | Ashley Bischoff | [@handcoding](https://twitter.com/handcoding) |
 | Becky Gibson | [@becka11y](https://twitter.com/becka11y) |
 | Billy Gregory | [@thebillygregory](https://twitter.com/thebillygregory) |
+| Bruno Pulis | [@obrunopulis](https://twitter.com/obrunopulis) |
+| Cameron Cundiff | [@ckundo](https://twitter.com/ckundo) |
 | Carie Fisher | [@cariefisher](https://twitter.com/cariefisher) |
+| Charlie Turrell | [@AccessibilityC3](https://twitter.com/AccessibilityC3) |
 | Claudia Nascimento | [@claumartin](https://twitter.com/claumartin)
+| Claudio Luís Vera | [@modulist](https://twitter.com/modulist)
 | Cordelia McGee-Tubb | [@cordeliadillon](https://twitter.com/cordeliadillon) |
 | Cynthia Shelly | [@cyns](https://twitter.com/cyns) |
+| Daniel Göransson | [@DanielGoransson](https://twitter.com/DanielGoransson) |
 | Darek Kay | [@darek_kay](https://twitter.com/darek_kay) |
 | Dave Rupert | [@davatron5000](https://twitter.com/davatron5000) |
 | David A. Kennedy | [@davidakennedy](https://twitter.com/davidakennedy) |
@@ -40,6 +47,7 @@ This is a list, in no particular order, of people to follow that contribute grea
 | Glenda Sims | [@goodwitch](https://twitter.com/goodwitch) |
 | Graham Armfield | [@coolfields](https://twitter.com/coolfields) |
 | Greg Tarnoff | [@gregtarnoff](https://twitter.com/gregtarnoff) |
+| Harcourt Hamsa | [@freescrpt](https://twitter.com/freescrpt) |
 | Hector Minto | [@hminto](https://twitter.com/hminto) |
 | Helena McCabe | [@misshelenasue](https://twitter.com/misshelenasue) |
 | Henny Swan | [@iheni](https://twitter.com/iheni) |
@@ -67,6 +75,7 @@ This is a list, in no particular order, of people to follow that contribute grea
 | Laura Carlson | [@laura_carlson](https://twitter.com/laura_carlson) |
 | Laura Kalbag | [@laurakalbag](https://twitter.com/laurakalbag) |
 | Léonie Watson | [@LeonieWatson](http://twitter.com/LeonieWatson) |
+| Luis Garcia | [@garcialo](https://twitter.com/garcialo) |
 | Lucy Greco | [@accessaces](https://twitter.com/accessaces) |
 | Luke McGrath | [@lukejmcgrath](https://twitter.com/lukejmcgrath) |
 | Manjula Dube | [@manjula_dube](https://twitter.com/mmatuzomanjula_dube) |
@@ -87,6 +96,7 @@ This is a list, in no particular order, of people to follow that contribute grea
 | Paul Adam | [@pauljadam](https://twitter.com/pauljadam) |
 | Reinaldo Ferraz | [@reinaldoferraz](https://twitter.com/reinaldoferraz) |
 | Rachel Carden | [@bamadesigner](https://twitter.com/bamadesigner) |
+| Rachel R. Vasquez | [@RachelRVasquez](https://twitter.com/RachelRVasquez) |
 | Rian Rietveld | [@RianRietveld](https://twitter.com/RianRietveld) |
 | Rob Dodson | [@rob_dodson](https://twitter.com/rob_dodson) |
 | Russ Weakley | [@russmaxdesign](https://twitter.com/russmaxdesign) |
@@ -98,6 +108,9 @@ This is a list, in no particular order, of people to follow that contribute grea
 | Shawn Lawton Henry | [@shawn_slh](https://twitter.com/shawn_slh) |
 | Sina Bahram | [@SinaBahram](https://twitter.com/SinaBahram) |
 | Sommer Panage | [@Sommer](https://twitter.com/Sommer) |
+| Stefan Judis | [@stefanjudis](https://twitter.com/stefanjudis) |
+| Steph Slattery [@sublimemarch](https://twitter.com/sublimemarch) |
 | Steve Faulkner | [@stevefaulkner](https://twitter.com/stevefaulkner) |
+| Suz Hinton | [@noopkat](https://twitter.com/noopkat) |
 | Svetlana Kouznetsova | [@svknyc](https://twitter.com/svknyc) |
 | Ted Drake | [@ted_drake](https://twitter.com/ted_drake) |


### PR DESCRIPTION
As discussed in #127, Joe's list is not being maintained/updated anymore. That's why I [proposed](https://github.com/a11yproject/a11yproject.com/issues/707) to update the "who to follow" section from [The A11y Project](https://www.a11yproject.com/follow/) to this repository instead.

That's why I've updated the resources once again, adding some more people, companies and meetups. I've also created a conferences section.