### PR TITLE
Add Podcasts section

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Image is an illustration by [Heydon Pickering](http://www.heydonworks.com/) whic
 
 **Table of Contents**
 
-- [Accessibility Weekly](topics/newsletter.md)  
+- [Accessibility Weekly](topics/newsletter.md)
 - [Articles and Videos](topics/articles-and-videos.md)
 - [Assistive Technology](topics/assistive-technology.md)
 - [Blogs](topics/blogs.md)
@@ -29,6 +29,7 @@ Image is an illustration by [Heydon Pickering](http://www.heydonworks.com/) whic
 - [Meetups](topics/meetups.md)
 - [Other Resources](topics/other-resources.md)
 - [People to Follow in Web Accessibility](topics/people.md)
+- [Podcasts](topics/podcasts.md)
 - [Talks](topics/talks.md)
 - [Tools](topics/tools.md)
 - [W3C Specification](topics/specification.md)

--- a/topics/podcasts.md
+++ b/topics/podcasts.md
@@ -1,0 +1,7 @@
+## Podcasts
+
+### Podcast Series
+* [A11y Rules](https://a11yrules.com/)
+
+### Specific Episodes
+* [NPR Throughline: A.D.A. Now!](https://www.npr.org/2020/07/27/895896462/a-d-a-now)


### PR DESCRIPTION
Made separate subsections to divide podcasts dedicated to the topic and specific episodes of podcasts not focused exclusively on accessibility. Could use a better heading title.

Resolves #124 