### PR TITLE
Change US gov guide to digital.gov

### DIFF
--- a/topics/guides.md
+++ b/topics/guides.md
@@ -26,5 +26,5 @@
 | [Web Accessibility Tutorials](http://www.w3.org/WAI/tutorials/) | EN |
 | [UK Home Office's Do's and Don'ts](https://github.com/UKHomeOffice/posters/tree/master/accessibility/dos-donts) | MULTIPLE |
 | [UK Government's accessibility guide](https://www.gov.uk/service-manual/helping-people-to-use-your-service/making-your-service-accessible-an-introduction) | EN |
-| [USA Government's accessibility guide](https://accessibility.18f.gov/) | EN |
+| [USA Government's accessibility guide](https://digital.gov/guides/accessibility-for-teams/) | EN |
 | [WebAIM WCAG 2.1 Checklist](https://webaim.org/standards/wcag/checklist) | EN |


### PR DESCRIPTION
The 18F guide is [no longer maintained](https://github.com/18F/accessibility). The [Accessibility for Teams](https://digital.gov/guides/accessibility-for-teams/) guide on digital.gov is a suitable successor.