### PR TITLE
Add Web Accessibility Checker to tools list

### DIFF
--- a/topics/tools.md
+++ b/topics/tools.md
@@ -35,6 +35,7 @@
 |[Site Unseen](https://chrome.google.com/webstore/detail/site-unseen/aflfgnngnnhdoffmmpmakkdflfedldlh?hl=en)|A screen reader emulator that enables you to experience the web from the perspective of a person who is blind |
 |[Stylelint a11y](https://github.com/YozhikM/stylelint-a11y)|Stylelint a11y|
 |[Virtual Screen Reader](https://github.com/guidepup/virtual-screen-reader)|Virtual screen reader driver for unit test automation.|
+|[Web Accessibility Checker](https://web-accessibility-checker.com)|Free online WCAG 2.1 accessibility testing tool that scans any webpage for compliance issues and provides actionable fixes.
 |[Web Accessibility Toolbar (WAT)](https://www.paciellogroup.com/resources/wat/)|The Web Accessibility Toolbar (WAT) has been developed to aid manual examination of web pages for a variety of aspects of accessibility.
 |[AltTextLab](https://www.alttextlab.com/)|AI-powered alt text generator for images.
 


### PR DESCRIPTION
## Summary

- Adds [Web Accessibility Checker](https://web-accessibility-checker.com) to the main Tools table in `topics/tools.md`
- Placed in alphabetical order (before Web Accessibility Toolbar)
- Free online WCAG 2.1 accessibility testing tool that scans webpages for compliance issues and provides actionable fixes

## Checklist

- [x] Added description
- [x] Placed in alphabetical order
- [x] Checked spelling and grammar
- [x] No trailing whitespace
- [x] Searched previous issues/PRs — no duplicate found