### PR TITLE
Add aria-eyes — color claim verification tool

### DIFF
--- a/topics/tools.md
+++ b/topics/tools.md
@@ -1,131 +1,262 @@
 ## Tools
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 | Tool | Description
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 | --- | --- |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[A11Y.css](https://github.com/ffoodd/a11y.css)|This CSS file intends to warn developers about possible risks and mistakes that exist in HTML code
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[A11yWatch](https://github.com/a11ywatch/a11ywatch)| The powerful web accessibility tool.
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[A11y Command-line Tools](https://addyosmani.com/a11y/)| Web accessibility audits powered by the Chrome Accessibility Developer Tools
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[a11y-checker](https://github.com/Muhnad/a11y-checker)| Warn about HTML Markup code accessibility issue
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[AcessibilityJS](https://github.com/github/accessibilityjs)|Client side accessibility error scanner
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[AccessLint](https://www.accesslint.com/)|A GitHub App that finds accessibility issues in your pull requests
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[Accessibility Developer Tools](https://github.com/GoogleChrome/accessibility-developer-tools)|This is a library of accessibility-related testing and utility code.
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[Accessibility DevKit](https://github.com/lukeslp/accessibility-devkit)|TypeScript packages for building accessible web applications targeting WCAG 2.2 AA — axe-core auditing, focus traps, contrast math, and color blindness simulation.|
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[Accessibility DevKit LLM](https://github.com/lukeslp/accessibility-devkit-llm)|Alt text generation, WCAG auditing CLI, and MCP server using language models for accessibility workflows. Works with OpenAI, Anthropic, HuggingFace, and Ollama.|
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[Accessibility Multiskill](https://github.com/lukeslp/accessibility-multiskill)|WCAG 2.2 AA skill for coding agents (Claude Code, Codex, Cursor) covering motor, cognitive, visual, and communication disabilities. Includes 10 audit scripts and production CSS utilities.|
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[Alt Text Local AI](https://github.com/lukeslp/alt-text-local-ai)|Desktop app that generates alt text for images using local Ollama vision models — no API key needed, nothing leaves your machine.|
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[Appt](https://appt.org/en) | A guide for making apps accessible
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[BA II Plus Accessible Calculator](https://github.com/shankar1593/accessible_tools)|Screen-reader-first web-based replica of the TI BA II Plus financial calculator for blind and low-vision CFA/FRM candidates. WCAG 2.1 AA and WAI-ARIA 1.1 compliant.|
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[ARIA DevTools](https://chrome.google.com/webstore/detail/aria-devtools/dneemiigcbbgbdjlcdjjnianlikimpck)|Chrome extension that displays a developer-friendly visual representation of the browser accessibility tree.
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[aslint.org](https://www.aslint.org/)|Accessibility testing tool
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[aXe Core](https://www.npmjs.com/package/axe-core)|Chrome and Firefox extension to audit pages
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[Checka11y.css](https://checka11y.jackdomleo.dev) | A CSS stylesheet to quickly highlight a11y concerns.
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[Chrome extension: IBM Equal Access Accessibility Checker](https://chrome.google.com/webstore/detail/ibm-equal-access-accessib/lkcagbfjnkomcinoddgooolagloogehp)| A Chrome extension web developer tool that checks web applications for accessibility issues.
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[Depression-Sensitive Web Content Support (DS-WCS)](https://github.com/simonplmak-cloud/depression-sensitive-web-content)|An OpenCode skill that audits and rewrites UI content (error messages, CTAs, forms, empty states) for cognitive accessibility. Maps findings to WCAG 2.2, W3C COGA, ISO 9241-110, and ISO/IEC 30071-1. MIT license, free to install.
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[Enabler](https://github.com/musienkoyuriy/enabler)|Node.js CLI tool that warns you about potential accessibility issues. Supports: Pure HTML, Angular, Vue
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[Firefox add-on: IBM Equal Access Accessibility Checker](https://addons.mozilla.org/en-US/firefox/addon/accessibility-checker/)| A firefox addon web developer tool that checks web applications for accessibility issues.
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[GetWCAG](https://getwcag.com/)|  Automated test that checks web applications for accessibility issues. From single page to full website in minutes |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[Guia WCAG](https://guia-wcag.com/)|  A guide to know better the guidelines of WCAG in PT-BR |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[Guidepup](https://github.com/guidepup/guidepup)|Screen reader driver for test automation.|
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[Headings Map](https://addons.mozilla.org/en-US/firefox/addon/headingsmap/)|The extension generates a document-map or index of any web document structured with headings and/or with sections in HTML 5. It shows the headings structure, the errors in the structure (ie. incorrect levels), and it works as HTML5 Outliner too.
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[HTML5 Acessibility](http://www.html5accessibility.com/)|Get the current accessibility support status of HTML5 features across major browsers
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[npm package: accessibility-checker](https://www.npmjs.com/package/accessibility-checker)| accessibility-checker is a NodeJS Module that allows you to perform integrated accessibility testing within a continuous integration pipeline such as Travis CI.
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[npm package: cypress-accessibility-checker](https://www.npmjs.com/package/cypress-accessibility-checker)| Cypress plugin for Accessibility Testing. This plugin is a Cypress flavor of the NodeJS version of accessibility-checker
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[RatedWithAI](https://ratedwithai.com/)| AI-powered website accessibility scanner that checks for ADA and WCAG 2.2 compliance, powered by axe-core. Free instant audit with actionable fix recommendations.
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[This is WCAG](https://thisiswcag.com/)| A guide to know better the guidelines of WCAG |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[Site Unseen](https://chrome.google.com/webstore/detail/site-unseen/aflfgnngnnhdoffmmpmakkdflfedldlh?hl=en)|A screen reader emulator that enables you to experience the web from the perspective of a person who is blind |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[Stylelint a11y](https://github.com/YozhikM/stylelint-a11y)|Stylelint a11y|
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[Virtual Screen Reader](https://github.com/guidepup/virtual-screen-reader)|Virtual screen reader driver for unit test automation.|
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[Web Accessibility Toolbar (WAT)](https://www.paciellogroup.com/resources/wat/)|The Web Accessibility Toolbar (WAT) has been developed to aid manual examination of web pages for a variety of aspects of accessibility.
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[AltTextLab](https://www.alttextlab.com/)|AI-powered alt text generator for images.
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 ### Assistive Technologies
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 - [Awesome Assistive Technology](https://github.com/openassistive/awesome-assistivetech)
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 #### Screen Readers
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 | Name | Created by | Type | Operating System | Cost |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |---|---|---|---|---|
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 | [Android Accessibility Suite](https://play.google.com/store/apps/details?id=com.google.android.marvin.talkback) | Google | Mobile app | Android | Free |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 | [ChromeVox](http://www.chromevox.com/) | Google | Desktop app | Chrome OS (built-in) | Free |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 | [JAWS](https://www.freedomscientific.com/Products/software/JAWS/) | Freedom Scientific | Desktop app | Windows | [Paid](https://www.freedomscientific.com/products/software/jaws/#compare) |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 | [Narrator](https://support.microsoft.com/en-us/windows/complete-guide-to-narrator-e4397a0d-ef4f-b386-d8ae-c172f109bdb1) | Microsoft | Desktop app | Windows 11, Windows 10 (built-in) | Free |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 | [NVDA](https://www.nvaccess.org/download/) | [NV Access](https://www.nvaccess.org/) | Desktop app | Windows | Free |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 | [Orca](https://wiki.gnome.org/Projects/Orca) | The Gnome Project | Desktop app | Linux | Free |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 | [VoiceOver](https://www.apple.com/accessibility/vision/) | Apple | Desktop app, mobile app | macOS, iOS (built-in) | Free |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 #### On Screen Keyboards (OSK)
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 | Name | Operating system(s) |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |---   |---                  |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 | [OptiKey](https://github.com/OptiKey/OptiKey/wiki) | Windows |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 | [Windows On-Screen Keyboard](https://support.microsoft.com/en-us/help/10762/windows-use-on-screen-keyboard) | Windows 10, 8.1, and 7 |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 #### Voice Control
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 | Name | Operating System | Cost | FOSS |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |---|---|---|---|
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 | [Numen](https://numenvoice.org) | Linux | Free | Open Source |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 | [Talon](https://talonvoice.com) | Windows, Mac, Linux (X11 only) | Free/Paid | Closed Source |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 | [TypeWhisper](https://www.typewhisper.com) | macOS, Windows | Free | Open Source |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 | [Voice Attack](https://voiceattack.com) | Windows | Free/Paid | Closed Source |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 ### Bookmarklets
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 | Type | Name | Created By | Cost |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |---   |---   |--- |--- |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |Bookmarklet | [A11y Tools](https://a11y-tools.com/bookmarklets) | A11y Tools | Free |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |Bookmarklet | [Accessibility Checker](https://Accessi.org) | Accessi.org | Free |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |Bookmarklet | [Ajbar](https://howlowck.github.io/Akbar/) | Hao Luo | Free |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |Bookmarklet | [ANDI](https://www.ssa.gov/accessibility/andi/help/howtouse.html) | [The United States Social Security Administration](https://www.ssa.gov/accessibility/andi/help/howtouse.html) | Free |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |Bookmarklet | [Focus Order Favlet](https://labs.levelaccess.com/index.php/Focus_Order_Favlet) | Level Access | Free |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |Bookmarklet | [Inacessible Twitter](https://defaced.dev/tools/inaccessible-twitter/) | Chris Johnson |Free |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |Bookmarklet | [Javascript Bookmarklets for Accessibility](https://pauljadam.com/bookmarklets/index.html)| Paul Jadam | Free |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |Bookmarklet | [Nu Markup Validation Service Bookmarklets](https://developer.paciellogroup.com/blog/2012/06/nu-markup-validation-service-bookmarklets/) | The Paciello Group |Free |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |Bookmarklet | [The Visual ARIA Bookmarklet](http://whatsock.com/training/matrices/visual-aria.htm) | WhatSock |Free |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |Bookmarklet | [tota11y](http://khan.github.io/tota11y/) | Khan Academy |Free |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 ### Colors and contrast
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 | Tool | Description
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 | --- | --- |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[a11y-contrast](https://github.com/darekkay/a11y-contrast)| A CLI utility to calculate/verify accessible magic numbers for a color palette
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[Accessible Colors](https://accessible-colors.com/)|
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[Check My Colours](http://www.checkmycolours.com/)|Validator of Color Constrast
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[Chromelens - Extension Google Chrome](http://chromelens.xyz/)|
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[Color Contrast Checker](https://coolors.co/contrast-checker/112a46-acc8e5) |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[Colour Contrast Analyser](https://www.paciellogroup.com/resources/contrastanalyser/)| To test the contrast of your text against its background
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[Color Oracle](http://colororacle.org/)| App (Mac/Win/Linux) for check colours
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[Tanaguru Contrast Finder](http://contrast-finder.tanaguru.com/?lang=en)|Contrast finder that suggests a valid color range
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[Who Can use](https://whocanuse.com/)||
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 ### Validators
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 | Validator | Description
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 | --- | --- |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[Access Monitor](http://accessmonitor.acessibilidade.gov.pt/)|Validator|
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[AMA Web](https://amaweb.unifesp.br/) | Validator PT-BR |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[ExcellentWebCheck](https://excellentwebcheck.com/website-accessibility-checker)|Mobile, Tablet and Desktop Accessibility Checker & Monitor|
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[Google Lighthouse](https://developers.google.com/web/tools/lighthouse/)|Google Chrome tool for web page audits
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[PageGuard](https://pageguard.qiudeqiu.workers.dev)|Free website scanner with WCAG 2.1 AA accessibility audit. Checks ARIA labels, color contrast, keyboard navigation, heading structure, image alt text, and more. No signup required, results in ~30 seconds.|
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[Sim Daltonism](https://michelf.ca/projects/sim-daltonism/)|A color blindness simulator for Mac and iOS
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[levelaccess](https://www.levelaccess.com/solutions/accessibility-audit-and-testing/)|Accessibility Auditing|
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[tota11y - Accessibility Visualization Toolkit](http://khan.github.io/tota11y/)| Simple validator using bookmarklet or Javascript plugin
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[WAVE](http://wave.webaim.org/)|Validator online| A tool that brings attention and understanding to how color contrast can affect different people with visual impairments.
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 ### Plugins for frameworks and CMS
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 | Validator | Description
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 | --- | --- |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[Accessibility New Window Warnings](https://wordpress.org/plugins/accessibility-new-window-warnings/)|A WordPress plugin that automatically adds visual and screen reader warnings for links that open in new tabs or windows. 
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[ArchiveWP](https://equalizedigital.com/archivewp/) | A WordPress Plugin for creating an archive of legacy content as required for exceptions by accessibility laws such as the ADA, EAA.
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[Ember A11y Testing](https://github.com/ember-a11y/ember-a11y-testing)| A suite of accessibility tests that can be run within the Ember testing framework
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[eslint-plugin-jsx-a11y](https://www.npmjs.com/package/eslint-plugin-jsx-a11y)| A static analysis linter of jsx and their accessibility with screen readers
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[eslint-plugin-vue-a11y](https://github.com/maranran/eslint-plugin-vue-a11y)| Static AST checker for accessibility rules on elements in .vue
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[Equalize Digital Accessibility Checker](https://equalizedigital.com/accessibility-checker) | A WordPress Plugin that helps you find and fix accessibility problems. |
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[React A11y](https://github.com/reactjs/react-a11y)|Identifies accessibility issues in your React.js elements
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[ReCalibri](https://github.com/lukeslp/recalibri)|Browser extension that replaces Times New Roman with accessible fonts (Calibri, Aptos, Open Sans, Lexend, Atkinson Hyperlegible, OpenDyslexic) for Chrome and Firefox.|
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[pa11y](http://www.pa11y.org/)|
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[ReaKit](https://reakit.io/)| Reakit is a low level component library for building accessible high level UI libraries, design systems and applications with React.
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[vue-a11y-utils](https://github.com/Jinjiang/vue-a11y-utils)| Utilities for accessibility (a11y) in Vue.js
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[vue-axe](https://github.com/vue-a11y/vue-axe)| Accessibility auditing for Vue.js applications
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|
 |[WP Accessibility](https://www.joedolson.com/wp-accessibility/)|Helps with a variety of common accessibility problems in WP themes
+|[aria-eyes](https://github.com/TonciZ/aria-eyes)|Automated color claim verification for aria-labels and alt text. Checks that color words match actual CSS colors (WCAG 1.4.1, 1.1.1).|


### PR DESCRIPTION
Adds aria-eyes to the Tools section. It verifies that color words in aria-labels and alt text match the actual rendered CSS colors, automating checks for WCAG 1.4.1 (Use of Color) and 1.1.1 (Non-text Content). No existing tool covers this gap.

- [GitHub repo](https://github.com/TonciZ/aria-eyes)
- [Live demo](https://tonciz.github.io/aria-eyes/)
- MIT licensed, TypeScript, framework-agnostic core + Playwright plugin