### PR TITLE
  Add WCAGsafe to Tools

### DIFF
--- a/topics/tools.md
+++ b/topics/tools.md
@@ -35,6 +35,9 @@
 |[Site Unseen](https://chrome.google.com/webstore/detail/site-unseen/aflfgnngnnhdoffmmpmakkdflfedldlh?hl=en)|A screen reader emulator that enables you to experience the web from the perspective of a person who is blind |
 |[Stylelint a11y](https://github.com/YozhikM/stylelint-a11y)|Stylelint a11y|
 |[Virtual Screen Reader](https://github.com/guidepup/virtual-screen-reader)|Virtual screen reader driver for unit test automation.|
+ |[WCAGsafe](https://wcagsafe.com)|WCAG 2.1 AA website and PDF accessibility   
+  scanner — plain-English results, legal risk indicator, AI-generated fix
+  instructions, and monthly monitoring. No installation required.|
 |[Web Accessibility Toolbar (WAT)](https://www.paciellogroup.com/resources/wat/)|The Web Accessibility Toolbar (WAT) has been developed to aid manual examination of web pages for a variety of aspects of accessibility.
 |[AltTextLab](https://www.alttextlab.com/)|AI-powered alt text generator for images.
 

--- a/topics/tools.md
+++ b/topics/tools.md
@@ -35,9 +35,7 @@
 |[Site Unseen](https://chrome.google.com/webstore/detail/site-unseen/aflfgnngnnhdoffmmpmakkdflfedldlh?hl=en)|A screen reader emulator that enables you to experience the web from the perspective of a person who is blind |
 |[Stylelint a11y](https://github.com/YozhikM/stylelint-a11y)|Stylelint a11y|
 |[Virtual Screen Reader](https://github.com/guidepup/virtual-screen-reader)|Virtual screen reader driver for unit test automation.|
- |[WCAGsafe](https://wcagsafe.com)|WCAG 2.1 AA website and PDF accessibility   
-  scanner — plain-English results, legal risk indicator, AI-generated fix
-  instructions, and monthly monitoring. No installation required.|
+|[WCAGsafe](https://wcagsafe.com)|WCAG 2.1 AA website and PDF accessibility scanner — plain-English results, legal risk indicator, AI-generated fix instructions, and monthly monitoring. No installation required.|
 |[Web Accessibility Toolbar (WAT)](https://www.paciellogroup.com/resources/wat/)|The Web Accessibility Toolbar (WAT) has been developed to aid manual examination of web pages for a variety of aspects of accessibility.
 |[AltTextLab](https://www.alttextlab.com/)|AI-powered alt text generator for images.
 


### PR DESCRIPTION
 WCAGsafe is a WCAG 2.1 AA accessibility scanner for websites and PDF documents. It uses axe-core under the hood and returns plain-English results with fix instructions — no setup required. Fits under Tools alongside other automated scanners like aXe Core and GetWCAG.

[WCAG Safe](https://wcagsafe.com)