### PR TITLE
Add Accessibility Checker Chrome extension to tools list

### DIFF
--- a/topics/tools.md
+++ b/topics/tools.md
@@ -8,6 +8,7 @@
 |[a11y-checker](https://github.com/Muhnad/a11y-checker)| Warn about HTML Markup code accessibility issue
 |[AcessibilityJS](https://github.com/github/accessibilityjs)|Client side accessibility error scanner
 |[AccessLint](https://www.accesslint.com/)|A GitHub App that finds accessibility issues in your pull requests
+|[Accessibility Checker — ADA & WCAG Scanner](https://chromewebstore.google.com/detail/kpodpjenpjodkoihfjibmdaoppeicklk)|Chrome extension for one-click WCAG 2.2 AA scanning. Shows compliance score, plain-English issue descriptions, element highlighting, dark pattern detection, and .gov ADA deadline alerts. Powered by axe-core. Free, privacy-first (all scanning is local).
 |[Accessibility Developer Tools](https://github.com/GoogleChrome/accessibility-developer-tools)|This is a library of accessibility-related testing and utility code.
 |[Accessibility DevKit](https://github.com/lukeslp/accessibility-devkit)|TypeScript packages for building accessible web applications targeting WCAG 2.2 AA — axe-core auditing, focus traps, contrast math, and color blindness simulation.|
 |[Accessibility DevKit LLM](https://github.com/lukeslp/accessibility-devkit-llm)|Alt text generation, WCAG auditing CLI, and MCP server using language models for accessibility workflows. Works with OpenAI, Anthropic, HuggingFace, and Ollama.|


### PR DESCRIPTION
Adds [Accessibility Checker — ADA & WCAG Scanner](https://chromewebstore.google.com/detail/kpodpjenpjodkoihfjibmdaoppeicklk) to the tools table.

**What it does:** Free Chrome extension that runs a full WCAG 2.2 Level AA audit on any web page in one click. Shows a compliance score, plain-English issue descriptions, element highlighting, dark pattern detection (FTC guidelines), and .gov domain ADA deadline alerts.

**Why it fits:** Built on axe-core (already listed), adds a user-friendly Chrome extension wrapper that makes accessibility checking accessible to non-technical users. All scanning is local — no data sent to servers.

- [Chrome Web Store listing](https://chromewebstore.google.com/detail/kpodpjenpjodkoihfjibmdaoppeicklk)
- [Source on GitHub](https://github.com/cotto3/pageaudit-extension)
- [Privacy policy](https://pageauditors.com/privacy/extension)