### PR TITLE
Add site-roaster to Tools section

### DIFF
--- a/topics/tools.md
+++ b/topics/tools.md
@@ -33,6 +33,7 @@
 |[RatedWithAI](https://ratedwithai.com/)| AI-powered website accessibility scanner that checks for ADA and WCAG 2.2 compliance, powered by axe-core. Free instant audit with actionable fix recommendations.
 |[This is WCAG](https://thisiswcag.com/)| A guide to know better the guidelines of WCAG |
 |[Site Unseen](https://chrome.google.com/webstore/detail/site-unseen/aflfgnngnnhdoffmmpmakkdflfedldlh?hl=en)|A screen reader emulator that enables you to experience the web from the perspective of a person who is blind |
+|[site-roaster](https://www.npmjs.com/package/site-roaster)|Free, zero-dependency CLI tool that audits websites for accessibility (ARIA, alt text, color contrast, keyboard navigation), plus SEO, performance, security, and design. Run via `npx site-roaster <url>`.|
 |[Stylelint a11y](https://github.com/YozhikM/stylelint-a11y)|Stylelint a11y|
 |[Virtual Screen Reader](https://github.com/guidepup/virtual-screen-reader)|Virtual screen reader driver for unit test automation.|
 |[Web Accessibility Toolbar (WAT)](https://www.paciellogroup.com/resources/wat/)|The Web Accessibility Toolbar (WAT) has been developed to aid manual examination of web pages for a variety of aspects of accessibility.


### PR DESCRIPTION
Adds [site-roaster](https://www.npmjs.com/package/site-roaster) to the Tools table in alphabetical order.

**site-roaster** is a free, open-source, zero-dependency CLI tool that audits websites for accessibility issues including:
- ARIA attribute validation
- Alt text for images
- Color contrast issues
- Keyboard navigation
- Form labels
- Heading hierarchy

It also covers SEO, performance, security, and design — delivering a letter grade (A-F) with specific recommendations.

- Runs instantly via `npx site-roaster <url>`
- MIT licensed
- npm: https://www.npmjs.com/package/site-roaster
- Source: https://github.com/ryuno2525/autonomous-claude-agent