### PR TITLE
Add VertaaUX CLI

### DIFF
--- a/topics/tools.md
+++ b/topics/tools.md
@@ -34,6 +34,7 @@
 |[Site Unseen](https://chrome.google.com/webstore/detail/site-unseen/aflfgnngnnhdoffmmpmakkdflfedldlh?hl=en)|A screen reader emulator that enables you to experience the web from the perspective of a person who is blind |
 |[Stylelint a11y](https://github.com/YozhikM/stylelint-a11y)|Stylelint a11y|
 |[Tactual](https://github.com/tactual-dev/tactual)|Screen-reader navigation cost analyzer. Models the real effort for assistive technology (AT) users to find, reach, and operate interactive web content under 5 assistive-technology profiles. CLI, MCP server, and library API.
+|[VertaaUX CLI](https://github.com/VertaaUX/cli)|UX, accessibility, and conversion audits from the terminal and CI, with score-based quality gates, PR comments, and regression detection against a baseline.|
 |[Virtual Screen Reader](https://github.com/guidepup/virtual-screen-reader)|Virtual screen reader driver for unit test automation.|
 |[Web Accessibility Toolbar (WAT)](https://www.paciellogroup.com/resources/wat/)|The Web Accessibility Toolbar (WAT) has been developed to aid manual examination of web pages for a variety of aspects of accessibility.
 |[AltTextLab](https://www.alttextlab.com/)|AI-powered alt text generator for images.


### PR DESCRIPTION
## Summary

Adds [VertaaUX CLI](https://github.com/VertaaUX/cli) to the **Tools** list.

## What it is

UX, accessibility, and conversion audits from the terminal and CI — with score-based quality gates, PR comments, and regression detection against a baseline. Runs multiple analyzers (usability, clarity, IA, accessibility with axe-core + WCAG heuristics, keyboard navigation, semantics, conversion).

## Distribution

- npm: [`@vertaaux/cli`](https://www.npmjs.com/package/@vertaaux/cli)
- Homebrew: `brew install vertaaux/tap/vertaa`
- Docker: `ghcr.io/vertaaux/cli`
- GitHub Action: [vertaaux/audit-action](https://github.com/marketplace/actions/vertaaux-audit)

## Guidelines checklist

- [x] Added in alphabetical order (between `Tactual` and `Virtual Screen Reader`)
- [x] `title` + `description` included in the table row
- [x] Single-purpose PR, no trailing whitespace
- [x] Spelling/grammar checked
