### PR TITLE
Add Happy Tools Color Blindness Simulator to Colors and contrast

### DIFF
--- a/topics/tools.md
+++ b/topics/tools.md
@@ -95,6 +95,7 @@
 |[Color Contrast Checker](https://coolors.co/contrast-checker/112a46-acc8e5) |
 |[Colour Contrast Analyser](https://www.paciellogroup.com/resources/contrastanalyser/)| To test the contrast of your text against its background
 |[Color Oracle](http://colororacle.org/)| App (Mac/Win/Linux) for check colours
+|[Happy Tools — Color Blindness Simulator](https://happytools.org/color/blindness)| Simulate how colors and images look with protanopia, deuteranopia, tritanopia, and achromatopsia — runs entirely in the browser, no sign-up
 |[Tanaguru Contrast Finder](http://contrast-finder.tanaguru.com/?lang=en)|Contrast finder that suggests a valid color range
 |[WCAG Color Contrast Checker](https://www.davidmello.com/tools/color-contrast-checker)|Checks foreground and background color pairs against WCAG 2.1 AA and AAA thresholds, with colorblindness simulation for four deficiency types, accessible color variant suggestions, and a shareable URL
 |[Who Can use](https://whocanuse.com/)||


### PR DESCRIPTION
Adds [Happy Tools — Color Blindness Simulator](https://happytools.org/color/blindness) to the **Colors and contrast** section of `topics/tools.md`.

It's a free, in-browser simulator that lets you preview how a color or an uploaded image appears under protanopia, deuteranopia, tritanopia, and achromatopsia, side-by-side. No account or sign-up, runs entirely client-side.

Placed alphabetically between `Color Oracle` and `Tanaguru Contrast Finder`. One-line addition; no other changes.

Note: I am the owner of the Happy Tools.