### PR TITLE
Add axle (accessibility compliance CI) to Tools

### DIFF
--- a/topics/tools.md
+++ b/topics/tools.md
@@ -18,6 +18,7 @@
 |[ARIA DevTools](https://chrome.google.com/webstore/detail/aria-devtools/dneemiigcbbgbdjlcdjjnianlikimpck)|Chrome extension that displays a developer-friendly visual representation of the browser accessibility tree.
 |[aslint.org](https://www.aslint.org/)|Accessibility testing tool
 |[aXe Core](https://www.npmjs.com/package/axe-core)|Chrome and Firefox extension to audit pages
+|[axle — Accessibility Compliance CI](https://github.com/asafamos/axle-action)|WCAG 2.1 / 2.2 AA scanning on every pull request via GitHub Action. Produces a sticky PR comment with violations grouped by severity and, optionally, Claude-generated source-code fix diffs. Built for EAA 2025, ADA, and Israeli תקנה 35 enforcement. Also ships as an npm CLI and as Netlify / Cloudflare Pages / Vercel plugins. No runtime overlay widget.|
 |[Checka11y.css](https://checka11y.jackdomleo.dev) | A CSS stylesheet to quickly highlight a11y concerns.
 |[Chrome extension: IBM Equal Access Accessibility Checker](https://chrome.google.com/webstore/detail/ibm-equal-access-accessib/lkcagbfjnkomcinoddgooolagloogehp)| A Chrome extension web developer tool that checks web applications for accessibility issues.
 |[Depression-Sensitive Web Content Support (DS-WCS)](https://github.com/simonplmak-cloud/depression-sensitive-web-content)|An OpenCode skill that audits and rewrites UI content (error messages, CTAs, forms, empty states) for cognitive accessibility. Maps findings to WCAG 2.2, W3C COGA, ISO 9241-110, and ISO/IEC 30071-1. MIT license, free to install.


### PR DESCRIPTION
Adds [axle](https://github.com/asafamos/axle-action) to `topics/tools.md`, placed alphabetically right after aXe Core since they share the same scanning engine.

**What it does:** WCAG 2.1 / 2.2 AA scanning on every GitHub pull request. Composite Action on GitHub Marketplace. Produces a sticky PR comment with violations grouped by severity and, optionally, Claude-generated source-code fix diffs inline in the comment. Exits non-zero at a configurable severity threshold so teams can require it as a merge check.

**Built for:**
- **EAA 2025** (European Accessibility Act — enforceable since 28 June 2025)
- **ADA** (U.S. — WCAG 2.1 AA as de facto standard in court)
- **Israeli תקנה 35** (updated October 2024)

Also ships as an npm CLI (`axle-cli`) and as Netlify / Cloudflare Pages / Vercel plugins. No runtime overlay widget is injected — scans run against your URL from hosted infrastructure; the public page is not touched.

License: MIT. Happy to adjust description length / placement if a different format fits the list.