### PR TITLE
Add KeyboardTester.click hearing-age + monitor sharpness tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,5 @@ _Please read the [contribution guidelines](CONTRIBUTING.md) before contributing.
 ## Support me
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/U7U4IDQTS)
+
+- [KeyboardTester.click — Hearing & Sharpness Tests](https://keyboardtester.click/hearing-age-test.php) - Free browser-based screening tools: hearing-age test (8-22 kHz with mosquito tone), monitor sharpness test (Lagom 1px grid + RGB sub-pixel ruler) — useful for users with hearing or visual sensitivity. Open source.


### PR DESCRIPTION
Adds two browser-based accessibility-relevant testing tools:

- **Hearing Age Test** (https://keyboardtester.click/hearing-age-test.php) - Free hearing screening (8 kHz to 22 kHz) including the 17.4 kHz mosquito tone. Useful as a self-check for high-frequency hearing loss; with explicit warnings about Bluetooth codec roll-off (a real concern for accurate testing).
- **Monitor Sharpness Test** (https://keyboardtester.click/monitor-sharpness-test.php) - Lagom-style 1px pixel grid + multi-size text samples + RGB sub-pixel ruler. Helps users with visual sensitivity check display calibration / sharpness.

Both run entirely in browser, no install. Open source: https://github.com/nasirazizawan009/keyboardtester-click