### PR TITLE
Add A11y Starter Kit to Tools

### DIFF
--- a/topics/tools.md
+++ b/topics/tools.md
@@ -5,6 +5,7 @@
 |[A11Y.css](https://github.com/ffoodd/a11y.css)|This CSS file intends to warn developers about possible risks and mistakes that exist in HTML code
 |[A11yWatch](https://github.com/a11ywatch/a11ywatch)| The powerful web accessibility tool.
 |[a11y-checker](https://github.com/Muhnad/a11y-checker)| Warn about HTML Markup code accessibility issue
+|[A11y Starter Kit](https://github.com/thefrontkit/a11y-starter-kit-code)| Free, open-source Next.js starter kit with WCAG 2.1 AA compliant components, keyboard navigation, screen reader support, and reduced motion handling.
 |[AcessibilityJS](https://github.com/github/accessibilityjs)|Client side accessibility error scanner
 |[AccessLint](https://www.accesslint.com/)|A GitHub App that finds accessibility issues in your pull requests
 |[Accessibility Checker — ADA & WCAG Scanner](https://chromewebstore.google.com/detail/kpodpjenpjodkoihfjibmdaoppeicklk)|Chrome extension for one-click WCAG 2.2 AA scanning. Shows compliance score, plain-English issue descriptions, element highlighting, dark pattern detection, and .gov ADA deadline alerts. Powered by axe-core. Free, privacy-first (all scanning is local).


### PR DESCRIPTION
## What is A11y Starter Kit?

[A11y Starter Kit](https://github.com/thefrontkit/a11y-starter-kit-code) is a free, open-source Next.js starter kit built for accessibility-first development. It ships with:

- **WCAG 2.1 AA compliant** UI components (built on shadcn/ui + Tailwind CSS)
- **Keyboard navigation** throughout all interactive elements
- **Screen reader support** with proper ARIA attributes and semantic HTML
- **Reduced motion handling** via `prefers-reduced-motion`
- **Skip navigation link** on every page
- **44px minimum touch targets** for mobile accessibility
- **AA color contrast** ratios across light and dark themes

## Why add it?

There are plenty of accessibility testing and auditing tools in the list, but very few resources that give developers an accessible starting point for building new apps. This starter kit helps developers begin projects with accessibility built in from day one, rather than retrofitting it later.

## Checklist

- [x] Entry added in alphabetical order in the Tools section
- [x] Follows the existing table format
- [x] Includes a description
- [x] Link points to a public GitHub repository