### PR TITLE
Add lucid-lint to Tools

### DIFF
--- a/topics/tools.md
+++ b/topics/tools.md
@@ -28,6 +28,7 @@
 |[Guidepup](https://github.com/guidepup/guidepup)|Screen reader driver for test automation.|
 |[Headings Map](https://addons.mozilla.org/en-US/firefox/addon/headingsmap/)|The extension generates a document-map or index of any web document structured with headings and/or with sections in HTML 5. It shows the headings structure, the errors in the structure (ie. incorrect levels), and it works as HTML5 Outliner too.
 |[HTML5 Acessibility](http://www.html5accessibility.com/)|Get the current accessibility support status of HTML5 features across major browsers
+|[lucid-lint](https://github.com/bastien-gallay/lucid-lint)|Bilingual (EN/FR) cognitive accessibility linter for prose. Deterministic CLI: flags long sentences, complex words, and other readability blockers. Maps findings to WCAG, RGAA, and FALC.
 |[npm package: accessibility-checker](https://www.npmjs.com/package/accessibility-checker)| accessibility-checker is a NodeJS Module that allows you to perform integrated accessibility testing within a continuous integration pipeline such as Travis CI.
 |[npm package: cypress-accessibility-checker](https://www.npmjs.com/package/cypress-accessibility-checker)| Cypress plugin for Accessibility Testing. This plugin is a Cypress flavor of the NodeJS version of accessibility-checker
 |[RatedWithAI](https://ratedwithai.com/)| AI-powered website accessibility scanner that checks for ADA and WCAG 2.2 compliance, powered by axe-core. Free instant audit with actionable fix recommendations.


### PR DESCRIPTION
Adds [lucid-lint](https://github.com/bastien-gallay/lucid-lint) to the Tools section.

`lucid-lint` is a bilingual (EN / FR) cognitive accessibility linter for prose, written in Rust. It runs as a deterministic CLI — no network, no LLM — and ships 17 rules that flag long sentences, complex words, weak structure, and other readability blockers. Findings map to WCAG, RGAA, and FALC (Facile À Lire et à Comprendre), so audit teams can cite the same standards their reports already use.

Inserted in the main `## Tools` table at the alphabetical L slot, between `HTML5 Acessibility` and `npm package: accessibility-checker`. No new section; no trailing whitespace.