### PR TITLE
Add xa11y to Tools

### DIFF
--- a/topics/tools.md
+++ b/topics/tools.md
@@ -37,6 +37,7 @@
 |[Tactual](https://github.com/tactual-dev/tactual)|Screen-reader navigation cost analyzer. Models the real effort for assistive technology (AT) users to find, reach, and operate interactive web content under 5 assistive-technology profiles. CLI, MCP server, and library API.
 |[Virtual Screen Reader](https://github.com/guidepup/virtual-screen-reader)|Virtual screen reader driver for unit test automation.|
 |[Web Accessibility Toolbar (WAT)](https://www.paciellogroup.com/resources/wat/)|The Web Accessibility Toolbar (WAT) has been developed to aid manual examination of web pages for a variety of aspects of accessibility.
+|[xa11y](https://xa11y.dev)|Cross-platform library and CLI for the OS accessibility trees on macOS (AXUIElement), Windows (UI Automation), and Linux (AT-SPI2). Audit desktop applications, build assistive tools for native UI, and let AI agents read and operate desktop apps. Rust, Python, and Node bindings.|
 |[AltTextLab](https://www.alttextlab.com/)|AI-powered alt text generator for images.
 
 ### Assistive Technologies


### PR DESCRIPTION
## Summary

Adds [xa11y](https://xa11y.dev) to the Tools section. xa11y is a cross-platform library and CLI for the accessibility trees on macOS (AXUIElement), Windows (UI Automation), and Linux (AT-SPI2) available in Rust, Python, and Node.js.

The list's current Tools coverage is web-focused (axe-core, Pa11y, Lighthouse, WAVE) or wraps screen readers for test automation (Guidepup, Virtual Screen Reader). xa11y is a library for interacting with accessibility APIs directly for either building assistive tech tools or for automated testing.

  ## Checklist

  - [x] Alphabetical order maintained (placed after Web Accessibility Toolbar)
  - [x] Format matches existing entries
  - [x] All links valid
  - [x] No existing duplicates
  - [x] Spelling/grammar checked
  - [x] No trailing whitespace